### PR TITLE
Refactor API routes and update ingress configuration

### DIFF
--- a/api-gateway/app.js
+++ b/api-gateway/app.js
@@ -77,13 +77,13 @@ const authMiddleware = async (req, res, next) => {
 const businessPartnersUrl = process.env.BUSINESS_PARTNERS_URL || "http://business-partners-service:8082";
 // Proxy para business-partners-service (incluyendo Swagger) protegido con authMiddleware
 app.use(
-  "/api/business-partners",
+  "/api/partners",
   authMiddleware,
   createProxyMiddleware({
     target: businessPartnersUrl,
     changeOrigin: true,
     pathRewrite: {
-      "^/api/business-partners": "",
+      "^/api/partners": "/partners",
     },
   })
 );
@@ -97,7 +97,7 @@ app.use(
     target: employeeUrl,
     changeOrigin: true,
     pathRewrite: {
-      "^/api/employee": "",
+      "^/api/employee": "/employee",
     },
   })
 );

--- a/api-gateway/charts/templates/ingress.yaml
+++ b/api-gateway/charts/templates/ingress.yaml
@@ -7,16 +7,16 @@ metadata:
     {{- include "api-gateway.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /api/$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
+    # nginx.ingress.kubernetes.io/rewrite-target: /api/$2
+    # nginx.ingress.kubernetes.io/use-regex: "true"
     cert-manager.io/issuer: {{ .Values.issuer.name }}
 spec:
   rules:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - path: /api(/|$)(.*)
-            pathType: ImplementationSpecific
+          - path: /api
+            pathType: Prefix
             backend:
               service:
                 name: {{ include "api-gateway.fullname" . }}

--- a/api-gateway/charts/values-dev.yaml
+++ b/api-gateway/charts/values-dev.yaml
@@ -6,8 +6,8 @@ replicaCount: 1
 containerPort: 3000
 
 image:
-  repository: docker.io/seminariojalapa/api-gateway
-  tag: 'latest'
+  repository: docker.io/seminariojalapa/dev-api-gateway
+  tag: '5'
   pullPolicy: Always
 
 ingress:


### PR DESCRIPTION
- Changed business partners API route from "/api/business-partners" to "/api/partners".
- Updated path rewrite rule for business partners service.
- Modified employee API route to maintain consistency.
- Adjusted ingress path type from ImplementationSpecific to Prefix.
- Updated image repository and tag in values-dev.yaml for deployment.